### PR TITLE
Update safe dependencies to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.5</version>
+    <version>3.5.6</version>
     <relativePath/>
   </parent>
   <groupId>net.ssimmie</groupId>
@@ -92,16 +92,16 @@
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <pitest-maven-plugin.version>1.19.1</pitest-maven-plugin.version>
     <pitest-junit5-plugin.version>1.2.2</pitest-junit5-plugin.version>
-    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
     <cucumber.version>7.23.0</cucumber.version>
-    <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
     <maven-pmd-plugin.version>3.21.0</maven-pmd-plugin.version>
-    <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.9.6.0</spotbugs-maven-plugin.version>
     <findsecbugs-maven-plugin.version>1.12.0</findsecbugs-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <maven-jxr-plugin.version>3.5.0</maven-jxr-plugin.version>
     <equalsverifier.version>4.0.6</equalsverifier.version>
-    <fmt-maven-plugin.version>2.25</fmt-maven-plugin.version>
+    <fmt-maven-plugin.version>2.29</fmt-maven-plugin.version>
     <to-string-verifier.version>1.4.8</to-string-verifier.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
- Spring Boot: 3.5.5 → 3.5.6 (latest stable patch with security fixes)
- SpotBugs Maven Plugin: 4.9.3.0 → 4.9.6.0 (bug fixes and analysis improvements)
- fmt Maven Plugin: 2.25 → 2.29 (code formatting enhancements)
- Maven Surefire Plugin: 3.5.3 → 3.5.4 (test execution stability improvements)
- Maven Failsafe Plugin: 3.5.3 → 3.5.4 (integration test reliability fixes)

All updates are conservative patch/minor releases that maintain compatibility. Build tested and confirmed working with native image generation.

🤖 Generated with [Claude Code](https://claude.ai/code)